### PR TITLE
Release next version of crypto-java-lib

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -6,7 +6,7 @@
 
 	<groupId>ro.kuberam.libs.java</groupId>
 	<artifactId>crypto</artifactId>
-	<version>1.7</version>
+	<version>1.7.0-SNAPSHOT</version>
 	<name>EXPath Cryptographic Module</name>
 	<description>Java Library providing an EXPath Cryptographic Module</description>
 	<url>http://kuberam.ro/specs/expath/crypto/crypto.html</url>


### PR DESCRIPTION
Changed pom.xml to 1.7.0-SNAPSHOT in preparation to release a version 1.7.0 which never got release afaik. I'm perfectly fine with another version number as well but 1.7 is certainly not the one we want to start of with. 